### PR TITLE
Add devel clean to install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Launch UCSF ChimeraX (either via GUI or command line) e.g.
       
 In the UCSF ChimeraX command line, run the following command (ensuring you modify the path appropriately for your system):
 
-      devel build ~/path/to/where/you/saved/wiggle/; devel install ~/path/to/where/you/saved/wiggle/
+      devel clean ~/path/to/where/you/saved/wiggle; devel build ~/path/to/where/you/saved/wiggle/; devel install ~/path/to/where/you/saved/wiggle/
 
 The path should match your git cloned directory...
 


### PR DESCRIPTION
Hi,

Thanks for the tool!

As part of helping install this for our researchers, I learnt that `devel clean /path/to/wiggle` was mandatory for the ChimeraX install to recognise the wiggle install - even if the wiggle install is into your home directory.

This pull request is just to update the readme to reflect this.